### PR TITLE
APIVERSNUM correction for API changes

### DIFF
--- a/device.h
+++ b/device.h
@@ -22,7 +22,7 @@
 #include <vdr/dvbdevice.h>
 #include "deviceplugin.h"
 
-#if APIVERSNUM < 10723
+#if APIVERSNUM < 10724
 #define DEV_DVB_BASE     "/dev/dvb"
 #define DEV_DVB_ADAPTER  "adapter"
 #define DEV_DVB_FRONTEND "frontend"


### PR DESCRIPTION
Hi manio,

I took the liberty to correct the changes you introduced in 3b73ade.
The API changes were introduced _after_ 1.7.23 (which I happen to have running here :-).

Thus, we need to check vor APIVERSNUM < 10724 in device.h

Thanks for the awesome plugin!

Best,
Torsten
