### PR TITLE
New makefile caused permanent segfaults on Gentoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ VERSION = $(shell grep 'static const char \*VERSION *=' DVBAPI.h | awk '{ print 
 PKGCFG  = $(if $(VDRDIR),$(shell pkg-config --variable=$(1) $(VDRDIR)/vdr.pc),$(shell pkg-config --variable=$(1) vdr || pkg-config --variable=$(1) ../../../vdr.pc))
 LIBDIR  = $(DESTDIR)/$(call PKGCFG,libdir)
 LOCDIR  = $(DESTDIR)/$(call PKGCFG,locdir)
+PLGCFG  = $(call PKGCFG,plgcfg)
 #
 TMPDIR ?= /tmp
 
@@ -26,6 +27,10 @@ TMPDIR ?= /tmp
 
 export CFLAGS   = $(call PKGCFG,cflags)
 export CXXFLAGS = $(call PKGCFG,cxxflags)
+
+### Allow user defined options to overwrite defaults:
+
+-include $(PLGCFG)
 
 ### The version number of VDR's plugin API:
 


### PR DESCRIPTION
Hi, it turned out that inclusion of Make.config via vdr.pc was missing, this was causing the plugin to crash VDR right on starting up. I'm suspecting that -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE where not passed to the FFdecsa build, only to the rest of the plugin. But, anyway, inlcuding Make.config seems to be the way to go with plugins at this time...
Cheers, Lucian
