### PR TITLE
Makefile again adapted to vdr-1.7.36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ VERSION = $(shell grep 'static const char \*VERSION *=' DVBAPI.h | awk '{ print 
 
 # Use package data if installed...otherwise assume we're under the VDR source directory:
 PKGCFG  = $(if $(VDRDIR),$(shell pkg-config --variable=$(1) $(VDRDIR)/vdr.pc),$(shell pkg-config --variable=$(1) vdr || pkg-config --variable=$(1) ../../../vdr.pc))
-LIBDIR  = $(DESTDIR)$(call PKGCFG,libdir)
-LOCDIR  = $(DESTDIR)$(call PKGCFG,locdir)
+LIBDIR  = $(call PKGCFG,libdir)
+LOCDIR  = $(call PKGCFG,locdir)
 PLGCFG  = $(call PKGCFG,plgcfg)
 #
 TMPDIR ?= /tmp
@@ -129,47 +129,47 @@ endif
 ### Implicit rules:
 
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $(DEFINES) $(INCLUDES) $<
+	$(CXX) $(CXXFLAGS) -c $(DEFINES) $(INCLUDES) -o $@ $<
 
 ### Dependencies:
 
 MAKEDEP = $(CXX) -MM -MG
 DEPFILE = .dependencies
 $(DEPFILE): Makefile
-	@$(MAKEDEP) $(DEFINES) $(INCLUDES) $(OBJS:%.o=%.cpp) > $@
+	@$(MAKEDEP) $(CXXFLAGS) $(DEFINES) $(INCLUDES) $(OBJS:%.o=%.cpp) > $@
 
 -include $(DEPFILE)
 
 ### Targets:
 
 $(SOFILE): $(OBJS) $(FFDECSA)
-	$(CXX) $(CXXFLAGS) -shared $(OBJS) $(DECSALIB) -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $(OBJS) $(DECSALIB) -o $@
 
 libdvbapi-dvbsddevice.so: device-sd.o
-	$(CXX) $(CXXFLAGS) -shared $< -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $< -o $@
 
 libdvbapi-dvbhddevice.so: device-hd.o
-	$(CXX) $(CXXFLAGS) -shared $< -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $< -o $@
 
 libdvbapi-dvbufs9xx.so: device-ufs9xx.o
-	$(CXX) $(CXXFLAGS) -shared $< -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $< -o $@
 
 ifndef LIBDVBCSA
 $(FFDECSA): $(FFDECSADIR)/*.c $(FFDECSADIR)/*.h
-	@$(MAKE) COMPILER="$(CXX)" FLAGS="$(CXXFLAGS) $(CSAFLAGS)" PARALLEL_MODE=$(PARALLEL) -C $(FFDECSADIR) all
+	@$(MAKE) COMPILER="$(CXX)" FLAGS="$(CXXFLAGS) $(LDFLAGS) $(CSAFLAGS)" PARALLEL_MODE=$(PARALLEL) -C $(FFDECSADIR) all
 endif
 
 install-lib: $(SOFILE)
-	install -D $^ $(LIBDIR)/$^.$(APIVERSION)
+	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)
 
 install-devplug-sddvb: libdvbapi-dvbsddevice.so
-	install -D $^ $(LIBDIR)/$^.$(APIVERSION)
+	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)
 
 install-devplug-hddvb: libdvbapi-dvbhddevice.so
-	install -D $^ $(LIBDIR)/$^.$(APIVERSION)
+	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)
 
 install-devplug-ufs9xx: libdvbapi-dvbufs9xx.so
-	install -D $^ $(LIBDIR)/$^.$(APIVERSION)
+	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)
 
 install: install-lib $(DEVPLUGINSTALL)
 


### PR DESCRIPTION
Hi,

with vdr-1.7.36, the plugin Makefile has been again, modified. Let's hope this is the last change now (DESTDIR moved in the installing targets is quite a change for some distros like Gentoo which have to adapt to one final variant). The current Makefile may still work for you, but if this whole Makefile storm has settled, actually the very last format agreed upon by Klaus and Copperhead should be used consistently by all Plugins which claim they have switched to the "new" Makefile. So please adapt, I think it should work for you, too...

Cheers... L.
