### PR TITLE
separate targt ffdecsa-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,10 @@ dist: clean
 	@-rm -rf $(TMPDIR)/$(ARCHIVE)
 	@echo Distribution package created as $(PACKAGE).tgz
 
-clean:
+clean: clean-ffdecsa
 	@-rm -f $(OBJS) device-sd.o device-hd.o device-ufs9xx.o $(DEPFILE) *.so *.tgz core* *~
+
+clean-ffdecsa:
 ifndef LIBDVBCSA
 	@$(MAKE) -C $(FFDECSADIR) clean
 endif


### PR DESCRIPTION
Hi,

in the Gentoo ebuild (https://github.com/lucianm/gen2ovl-googoo2/blob/master/media-plugins/vdr-dvbapi/vdr-dvbapi-9999.ebuild), it comes handy to be able to clean the ffdecsa separately (you may look after 'emake clean-ffdecsa' in that link), when iterating through all PARALLEL_MODES in order to find out the best setting. Would be nice if you adopt this patch, thanks!

Ciao, Lucian
