### PR TITLE
DeCSAFillControl: adjust for small device buffers

### DIFF
--- a/SCCAMSlot.h
+++ b/SCCAMSlot.h
@@ -36,10 +36,10 @@ class DeCSAFillControl
 {
 private:
   int maxWaterMark, timeout, dataInterval;
-  int minWaterMark;
-  int lowWaterMark, lastCount;
+  int minWaterMark, sleepInterval;
+  int lowWaterMark, lastCount, timeSlept;
   const uchar *lastData;
-  enum {READY, SLEEP1, SLEEP2, WRAP} state;
+  enum {READY, SLEEP, WRAP} state;
   int fltTap1, fltTap2;
   int Filter(int Input);
 public:


### PR DESCRIPTION
Hi @manio.

satip and iptv plugins use 1MB device's ring buffers. So, I've made some changes for a "safer" sleep in such cases. Tested with a 1MB dvb device on ARM and x86_64.  TS streams up to 24 Mbit/s worked pretty well. But they (those plugins authors) should consider increasing the buffer size if those plugins are expected to work with dvbapi at high bit rates. It's not only about overflows, but also a performance issue. Maybe it's worth adding a statement for a device writers to the README file saying, that if a device is meant to be used with this plugin, it should have a ring buffer of size 5 MB or more.